### PR TITLE
Add exceptions for stadia and geforcenow to fix esc issue

### DIFF
--- a/trackers-unprotected-temporary.txt
+++ b/trackers-unprotected-temporary.txt
@@ -1,3 +1,5 @@
+play.geforcenow.com
+stadia.google.com
 calbanktrust.com
 fidelity.com
 vanguard.com
@@ -21,7 +23,6 @@ santander.com
 santander.co.uk
 usbank.com
 aternos.org
-theguardian.com
 nfl.com
 delivery-club.ru
 netteller.com


### PR DESCRIPTION
Fixes https://github.com/duckduckgo/duckduckgo-privacy-extension/issues/547.

Also remove theguardian.com from exception list as the issue there has been resolved.