### PR TITLE
Removing a few temp rules for domains that have since been fixed

### DIFF
--- a/trackers-unprotected-temporary.txt
+++ b/trackers-unprotected-temporary.txt
@@ -22,7 +22,3 @@ ameritrade.com
 santander.com
 santander.co.uk
 usbank.com
-aternos.org
-nfl.com
-delivery-club.ru
-netteller.com


### PR DESCRIPTION
aternos.org - site appears broken with protection on and off, so removing
nfl.com - videos confirmed working again
delivery-club.ru - requests to money.mail.ru no longer blocked
netteller.com - can't reproduce breakage any longer