### PR TITLE
Remove stadia and geforcenow from temp unprotected list

### DIFF
--- a/trackers-unprotected-temporary.txt
+++ b/trackers-unprotected-temporary.txt
@@ -1,6 +1,4 @@
 dropbox.com
-play.geforcenow.com
-stadia.google.com
 calbanktrust.com
 fidelity.com
 vanguard.com


### PR DESCRIPTION
Now that we've traced the esc key issue to the [injected anti fingerprinting script](https://github.com/duckduckgo/duckduckgo-privacy-extension/blob/develop/shared/js/injected-content-scripts/fingerprint-protection.js#L62-L66) that spoofs the keyboard API, we should remove the affected domains from the temp unprotected list.