### PR TITLE
Add aspiration.com to temp list

### DIFF
--- a/trackers-unprotected-temporary.txt
+++ b/trackers-unprotected-temporary.txt
@@ -26,4 +26,4 @@ schwab.com
 www.x-kom.pl
 delta.com
 chipotle.com
-aspiration.com
+www.aspiration.com


### PR DESCRIPTION
Because it's breaking. Will remove once next blocklist goes out with proper exception rule to fix site.