### PR TITLE
Strip www. from aspiration entry

### DIFF
--- a/trackers-unprotected-temporary.txt
+++ b/trackers-unprotected-temporary.txt
@@ -26,4 +26,4 @@ schwab.com
 www.x-kom.pl
 delta.com
 chipotle.com
-www.aspiration.com
+aspiration.com

--- a/trackers-whitelist-temporary.txt
+++ b/trackers-whitelist-temporary.txt
@@ -26,3 +26,4 @@ schwab.com
 www.x-kom.pl
 delta.com
 chipotle.com
+aspiration.com


### PR DESCRIPTION
Due to https://app.asana.com/0/312629933896096/1200316060887279 this is temporary for now.

The www.x-kom.pl entry is fine as the bug wasn't for the extension where the bug is.