### PR TITLE
Move johnlewis.com exceptions to canvas only

### DIFF
--- a/protections.json
+++ b/protections.json
@@ -3,6 +3,7 @@
         "enabled": true,
         "sites": [
             "www.delta.com",
+            "www.johnlewis.com",
             "warzone.com",
             "skribbl.io",
             "kroger.com",

--- a/trackers-unprotected-temporary.txt
+++ b/trackers-unprotected-temporary.txt
@@ -29,5 +29,4 @@ www.spiegel.de
 www.tentree.com
 www.dyson.com
 www.6play.fr
-www.johnlewis.com
 www.merriam-webster.com


### PR DESCRIPTION
https://app.asana.com/0/1200223097357040/1200518097540265

As this appears only to be a Canvas only breakage, moving this there to reduce exposure to safelisting.